### PR TITLE
fix king crash when I click it

### DIFF
--- a/src/core/chess.ts
+++ b/src/core/chess.ts
@@ -169,6 +169,7 @@ export default class Chess {
 
         if (
           piece &&
+          piece.pieceType !== 'king' &&
           piece.color === color &&
           this.getPieceMovements(c, r).find((m) => m.x === x && m.y === y)
         ) {

--- a/src/core/pieces/knight.ts
+++ b/src/core/pieces/knight.ts
@@ -23,7 +23,7 @@ export default class Knight extends Piece {
     ];
 
     knightPossibleMovs.forEach((possibleMov) =>
-      this.__addIfValidMovement(possibleMov.x, possibleMov.y, movements, chess),
+      this.__addIfValidMovement(possibleMov.x, possibleMov.y, movements, chess)
     );
 
     return movements;
@@ -50,8 +50,8 @@ export default class Knight extends Piece {
         possibleCapture.y,
         movements,
         pieceThatCaptures,
-        chess,
-      ),
+        chess
+      )
     );
 
     return movements;

--- a/src/core/test/chess.test.ts
+++ b/src/core/test/chess.test.ts
@@ -151,6 +151,20 @@ describe('Chess suite', () => {
       expect(chess.isCheckedPosition(3, 4, 'black')).toBe(false);
       expect(chess.isCheckedPosition(4, 4, 'black')).toBe(true);
     });
+
+    it('King should be able to move', () => {
+      const chess = new Chess();
+
+      // Move pawns
+      chess.move(4, 1, 4, 3);
+      chess.move(4, 6, 4, 4);
+
+      // King should be able to move
+      chess.move(4, 0, 4, 1);
+
+      expect(chess.hasPiece(4, 1)).toBe(true);
+      expect(chess.getPiece(4, 1).pieceType).toBe('king');
+    });
   });
 
   describe('.getPieceMovements(x, y)', () => {


### PR DESCRIPTION
Solución de crash del juego

Podes probar el juego asi como esta en master, mover el peon del rey blanco, despues mover el peon del rey negro, despues clickear el rey (como en el test) y ahi crashea.

Acá la solución: isCheckedPosition no tomará en cuenta reyes, ya que se producía un bucle infinito entre rey negro y rey blanco