### PR TITLE
Nailed Pieces

### DIFF
--- a/src/core/test/king.test.ts
+++ b/src/core/test/king.test.ts
@@ -16,7 +16,7 @@ describe('King suite', () => {
     expect(blackKing.color).toBe('black');
 
     expect(
-      arrayBoard.filter((piece) => piece && piece.pieceType === 'king').length,
+      arrayBoard.filter((piece) => piece && piece.pieceType === 'king').length
     ).toBe(2);
   });
 
@@ -111,4 +111,22 @@ describe('King suite', () => {
 
   //   expect(movements.find((m) => m.x === 4 && m.y === 5)).toBe(undefined);
   // });
+
+  test('A player cannot move a piece if, doing this, let his king checked', () => {
+    const chess = new Chess();
+
+    chess.cleanBoard();
+
+    chess.addPiece(new King('white'), 4, 3);
+    chess.addPiece(new Bishop('black'), 1, 6);
+
+    // This pawn is covering the king from the bishop,
+    // so it cannot move
+    chess.addPiece(new Pawn('white'), 3, 4);
+
+    const movements = chess.getPieceMovements(3, 4);
+
+    // The pawn cannot advance because it will let the king unprotected
+    expect(movements.find((m) => m.x === 3 && m.y === 5)).toBe(undefined);
+  });
 });


### PR DESCRIPTION
"Piezas clavadas", lo traducí literal
Una pieza clavada es una pieza que NO se puede mover ya que si se mueve, dejaría desprotegido al rey permitiendo al enemigo comerlo en la siguiente jugada, ganando automáticamente